### PR TITLE
Bugfix: Add backup inactivity timeout for Safari

### DIFF
--- a/default.env
+++ b/default.env
@@ -55,3 +55,12 @@ VITE_OIDC_LOGOUT_ENDPOINT=https://keycloak.inform.ubu.dlorigan.dev.cirg.uw.edu/r
 
 # URL to redirect to after logout completes
 VITE_POST_LOGOUT_REDIRECT_URI=https://inform.ubu.dlorigan.dev.cirg.uw.edu/users
+
+# Maximum allowable time without clicks, scrolling or tab switching; HH:MM:SS
+# Defaults to 4 hours
+#VITE_INACTIVITY_TIMEOUT=
+
+# Maximum allowable time without clicks, scrolling or tab switching; HH:MM:SS
+# Only applies when unable to perform standard session checks via iframe (e.g. Safari)
+# Defaults to 15 minutes
+#VITE_BACKUP_INACTIVITY_TIMEOUT=

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,6 +15,7 @@ interface ImportMetaEnv {
     readonly VITE_POST_LOGOUT_REDIRECT_URI: string
     readonly VITE_OIDC_CHECK_SESSION_IFRAME: string
     readonly VITE_INACTIVITY_TIMEOUT: string
+    readonly VITE_BACKUP_INACTIVITY_TIMEOUT: string
     readonly DEV_SERVER_PORT: number
 }
   

--- a/src/lib/SessionStatus.svelte
+++ b/src/lib/SessionStatus.svelte
@@ -72,7 +72,8 @@
       }
       if (sessionCheckValid) {
         // If check has been valid at some point, base action on result
-        // Clean up listeners if they were added before 
+        // Clean up timeout and listeners if they were added before
+        checkSession = undefined;
         document.removeEventListener('click', resetBackupInactivityTimer);
         document.removeEventListener('scroll', resetBackupInactivityTimer);
         document.removeEventListener('visibilitychange', onVisible_resetBackupInactivityTimer);

--- a/src/lib/SessionStatus.svelte
+++ b/src/lib/SessionStatus.svelte
@@ -50,7 +50,7 @@
   }
   function onVisible_resetBackupInactivityTimer() {
     if (document.visibilityState === "visible") {
-      onVisible_resetBackupInactivityTimer();
+      resetBackupInactivityTimer();
     }
   }
 

--- a/src/lib/SessionStatus.svelte
+++ b/src/lib/SessionStatus.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { onMount, getContext } from "svelte";
-  import { OIDC_BASE, CHECK_SESSION_IFRAME } from "./config";
+  import {
+    OIDC_BASE,
+    CHECK_SESSION_IFRAME,
+    BACKUP_INACTIVITY_TIMEOUT } from "./config";
   import { goto } from "$app/navigation";
   import type { SOFClient } from "./sofClient";
 
@@ -8,15 +11,16 @@
 
   // Poll the OP iframe periodically
   let checkSession = setInterval(checkSessionStatus, 5000);
+
+  let validatingSession = true;
+  let sessionCheckValid: boolean;
   
   onMount(() => {
     // Listen for messages from OP iframe
     window.addEventListener('message', processStatus);
-    // Check session on load
-    // checkSessionStatus();
+    // Check session status on iframe load
     let iframe = document.getElementById('opIframe');
     iframe?.addEventListener('load', () => {
-      // Poll the iframe on load
       checkSessionStatus();
     });
     // Check status as soon as the tab is refocused
@@ -29,26 +33,65 @@
 
   function checkSessionStatus() {
     var opIframe = document.getElementById('opIframe');
-    var message = `${sofClient.getClient().getState('clientId')} ${sofClient.getClient().getState('tokenResponse.session_state')}`;
+    var clientId = sofClient.getClient().getState('clientId');
+    var sessionId = sofClient.getClient().getState('tokenResponse.session_state');
+    var message = `${clientId} ${sessionId}`;
     // Send message to OP iframe
     opIframe?.contentWindow?.postMessage(message, OIDC_BASE);
+  }
+
+  let backupInactivityTimer: NodeJS.Timeout | undefined;
+  function resetBackupInactivityTimer() {
+    if (backupInactivityTimer !== undefined) {
+        clearTimeout(backupInactivityTimer);
+      }
+      backupInactivityTimer = undefined;
+      backupInactivityTimer = setTimeout(() => goto('/logout'), BACKUP_INACTIVITY_TIMEOUT);
+  }
+  function onVisible_resetBackupInactivityTimer() {
+    if (document.visibilityState === "visible") {
+      onVisible_resetBackupInactivityTimer();
+    }
   }
 
   async function processStatus(event: any) {
     if (event.origin === OIDC_BASE) {
       var data = event.data;
-      if (data === 'changed') {
-        try {
-          let res = await sofClient.getClient().refresh();
-          if (!sofClient?.getClient()?.getState("tokenResponse.access_token")) {
-            throw Error("Unable to refresh token after session state change. Logging out.");
+      if (validatingSession || (sessionCheckValid !== undefined && !sessionCheckValid)) {
+        // Don't check status if it's only been erroring, as in Safari w/o 3p cookies
+        // If check has been 'error' but is now something else, change state to valid
+        sessionCheckValid = (data !== 'error');
+        if (validatingSession && !sessionCheckValid) {
+          // Check has only errored, initialize timeout (or manual logout)
+          resetBackupInactivityTimer();
+          document.addEventListener('click', resetBackupInactivityTimer);
+          document.addEventListener('scroll', resetBackupInactivityTimer);
+          document.addEventListener('visibilitychange', onVisible_resetBackupInactivityTimer);
+        }
+        validatingSession = false;
+      }
+      if (sessionCheckValid) {
+        // If check has been valid at some point, base action on result
+        // Clean up listeners if they were added before 
+        document.removeEventListener('click', resetBackupInactivityTimer);
+        document.removeEventListener('scroll', resetBackupInactivityTimer);
+        document.removeEventListener('visibilitychange', onVisible_resetBackupInactivityTimer);
+
+        if (data === 'changed') {
+          try {
+            let res = await sofClient.getClient().refresh();
+            if (!sofClient?.getClient()?.getState("tokenResponse.access_token")) {
+              throw Error("Unable to refresh token after session state change. Logging out.");
+            }
+          } catch (e) {
+            console.error(e);
+            goto('/logout');
           }
-        } catch (e) {
-          console.error(e);
+        } else if (data === 'error') {
           goto('/logout');
         }
-      } else if (data === 'error') {
-        goto('/logout');
+      } else {
+        console.warn('Unable to verify session state. You will be logged out automatically after 15 minutes of inactivity.');
       }
     }
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,8 +13,13 @@ export const POST_LOGOUT_REDIRECT_URI = import.meta.env.VITE_POST_LOGOUT_REDIREC
 
 export const BACK_URL = import.meta.env.VITE_BACK_URL;
 
-const timeout = (import.meta.env.VITE_INACTIVITY_TIMEOUT ?? "04:00:00").split(":").map((n) => Number(n));
+const default_timout = "04:00:00";
+const timeout = (import.meta.env.VITE_INACTIVITY_TIMEOUT ?? default_timout).split(":").map((n) => Number(n));
 export const INACTIVITY_TIMEOUT = toMilliseconds(timeout[0] ?? 0, timeout[1] ?? 0, timeout[2] ?? 0);
+
+const default_backup_timout = "00:15:00";
+const backup_timeout = (import.meta.env.VITE_BACKUP_INACTIVITY_TIMEOUT ?? default_backup_timout).split(":").map((n) => Number(n));
+export const BACKUP_INACTIVITY_TIMEOUT = toMilliseconds(timeout[0] ?? 0, timeout[1] ?? 0, timeout[2] ?? 0);
 
 export const SOF_RESOURCES = [
   'Patient',


### PR DESCRIPTION
Safari doesn't allow 3rd party cookies, breaking the iframe session checks. This was resulting in a logout state, documented here:
https://cirg.slack.com/archives/C025H0S1UKB/p1712371650763699?thread_ts=1712329201.855859&cid=C025H0S1UKB

The app now checks that a non-error response has been received before allowing logouts on error
Until a non-error response is received, the client falls back to a shorter timeout period (default 15 min)