### PR TITLE
Draft: Add listener to navigate changes that reloads the page

### DIFF
--- a/static/view/assets/js/renderIPS.js
+++ b/static/view/assets/js/renderIPS.js
@@ -18,6 +18,10 @@ $(document).ready(function () {
   $('#content').show();
   $('#FhirDropdown').on('click', () => updateDisplayMode('Entries'));
   $('#NarrativeDropdown').on('click', () => updateDisplayMode('Text'));
+
+  window.navigation.addEventListener("navigate", (event) => {
+    location.reload();
+  });
 });
 
 function loadSample() {


### PR DESCRIPTION
Automatically refresh the page if the url href is changed. Previously, pasting a new shlink into the url bar of a window showing another report on the shl-viewer wouldn't reload the page or update the content without clicking refresh.
